### PR TITLE
chore: agregar soporte para postgresql en docker y crear .env.exampl

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,32 @@
+# DJANGO
+SECRET_KEY="insecurepassword34629834"
+DEBUG=1
+
+# DB usado por Django
+POSTGRESQL_ADDON_DB="mydb_oilshop"
+POSTGRESQL_ADDON_USER="myuser_oilshop"
+POSTGRESQL_ADDON_PASSWORD="mypassword_oilshop"
+POSTGRESQL_ADDON_PORT="5432"
+POSTGRESQL_ADDON_HOST="localhost"
+
+# DB usado por Docker 
+POSTGRES_DB="mydb_oilshop"
+POSTGRES_USER="myuser_oilshop"
+POSTGRES_PASSWORD="mypassword_oilshop"
+POSTGRES_PORT="5432"
+
+# CLOUDINARY
+CLOUD_NAME="el-nombre-de-mi-app-en-cloudinary"
+API_KEY="mi-api-key-en-cloudinary"
+API_SECRET="mi-secret-key-en-cloudinary"
+
+# EMAIL
+EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST="smtp.gmail.com"
+EMAIL_HOST_USER="micorreo@gmail.com"
+EMAIL_HOST_PASSWORD="mi-password-de-16-caracteres"
+EMAIL_PORT="587"
+EMAIL_USE_TLS="1"
+
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  db:
+    image: postgres:16
+    volumes:
+      - oilshop_dev_data:/var/lib/postgresql/data/
+    env_file:
+      - ./.env
+    ports:
+      - 5432:5432
+volumes:
+  oilshop_dev_data:

--- a/oilshop/settings.py
+++ b/oilshop/settings.py
@@ -14,22 +14,22 @@ import  os
 from pathlib import Path
 import cloudinary
 
-from decouple import config
+from decouple import config, Csv
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
-
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-ha8jkxc_z&opn@#w%!(&k8q(=k%5z*!*57s=dg-rqd#h*tazg)'
+SECRET_KEY = config("SECRET_KEY", default='django-insecure-ha8jkxc_z&opn@#w%!(&k8q(=k%5z*!*57s=dg-rqd#h*tazg)')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG =False
+DEBUG = config('DEBUG', cast=bool, default=True)
 
-ALLOWED_HOSTS = ['*']
+
+ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='', cast=Csv())
 
 
 # Application definition
@@ -130,13 +130,10 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
-
 # Default primary key field type
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
-
-
 
 MEDIA_ROOT=os.path.join(BASE_DIR,'media')
 MEDIA_URL='/media/'
@@ -152,7 +149,10 @@ DEFAULT_FILE_STORAGE = 'cloudinary_storage.storage.MediaCloudinaryStorage'
 
 # Looking to send emails in production? Check out our Email API/SMTP product!
 # Looking to send emails in production? Check out our Email API/SMTP product!
+EMAIL_BACKEND=config("EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend")
 EMAIL_HOST = config('EMAIL_HOST')
 EMAIL_HOST_USER = config('EMAIL_HOST_USER')
 EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD')
 EMAIL_PORT = config('EMAIL_PORT', cast=int)
+EMAIL_USE_TLS = config('EMAIL_USE_TLS', cast=bool, default=True)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
 django==3.2
 pillow
-
-
-mysqlclient
-
+# mysqlclient
 setuptools     
 psycopg2-binary
 django-paypal


### PR DESCRIPTION
# Cambios Realizados:
###  docker-compose.yml
Su proposito es permitir ejecutar una base de datos postgresql desde docker, sin necesidad de instalarla localmente, esto facilita el desarrollo.

### settigns.py 
agregué la lectura de variarles adicionales desde el entorno como: 
- SECRET_KEY
- DEBUG
- ALLOWED_HOSTS
- EMAIL_BACKEND
- EMAIL_USE_TLS

###  .env.example
Proporciona ejemplo de todas las variables que estan siendo utilizadas dentro de setting.py con esto al modificar el nombre del archivo por **.env** se agiliza el setup inicial de las variables

### comentar mysql en dependencias
**mysqlclient** poseee dependencias externas fuera de pip que no necesariamente estarán instaladas en la máquina local (como en mi caso) dado que no se está utilizando mysql en la app pienso que lo ideal sería comentar esta dependencia. 
